### PR TITLE
Configuration of join properties via lambda parameter to JoinService

### DIFF
--- a/src/DaybreakGames.Census/Operators/CensusJoin.cs
+++ b/src/DaybreakGames.Census/Operators/CensusJoin.cs
@@ -99,8 +99,7 @@ namespace DaybreakGames.Census.Operators
 
         public CensusJoin JoinService(string service, System.Action<CensusJoin> configuration)
         {
-            var newJoin = new CensusJoin(service);
-            Join.Add(newJoin);
+            var newJoin=JoinService(service);
             configuration(newJoin);
             return newJoin;
         }

--- a/src/DaybreakGames.Census/Operators/CensusJoin.cs
+++ b/src/DaybreakGames.Census/Operators/CensusJoin.cs
@@ -97,6 +97,14 @@ namespace DaybreakGames.Census.Operators
             return newJoin;
         }
 
+        public CensusJoin JoinService(string service, System.Action<CensusJoin> configuration)
+        {
+            var newJoin = new CensusJoin(service);
+            Join.Add(newJoin);
+            configuration(newJoin);
+            return newJoin;
+        }
+
         public override string ToString()
         {
             var baseString = base.ToString();

--- a/src/DaybreakGames.Census/Operators/CensusQuery.cs
+++ b/src/DaybreakGames.Census/Operators/CensusQuery.cs
@@ -115,6 +115,20 @@ namespace DaybreakGames.Census.Operators
             return newJoin;
         }
 
+        public CensusJoin JoinService(string service, Action<CensusJoin> configuration)
+        {
+            var newJoin = new CensusJoin(service);
+
+            if (Join == null)
+            {
+                Join = new List<CensusJoin>();
+            }
+
+            Join.Add(newJoin);
+            configuration(newJoin);
+            return newJoin;
+        }
+
         public CensusTree TreeField(string field)
         {
             var newTree = new CensusTree(field);

--- a/src/DaybreakGames.Census/Operators/CensusQuery.cs
+++ b/src/DaybreakGames.Census/Operators/CensusQuery.cs
@@ -117,14 +117,7 @@ namespace DaybreakGames.Census.Operators
 
         public CensusJoin JoinService(string service, Action<CensusJoin> configuration)
         {
-            var newJoin = new CensusJoin(service);
-
-            if (Join == null)
-            {
-                Join = new List<CensusJoin>();
-            }
-
-            Join.Add(newJoin);
+            var newJoin = JoinService(service);
             configuration(newJoin);
             return newJoin;
         }

--- a/test/DaybreakGames.Census.Test/CensusURITest.cs
+++ b/test/DaybreakGames.Census.Test/CensusURITest.cs
@@ -265,6 +265,30 @@ namespace DaybreakGames.Census.Test
         }
 
         [TestMethod]
+        public void Census_AddJoin_WithConfig()
+        {
+            var service = "character";
+            var ns = "ps2";
+            var key = "testkey";
+
+            var expectedUri = new Uri($"http://{Constants.CensusEndpoint}/s:{key}/get/{ns}/{service}/?c:join=joinedservice^terms:field1=12'field2=34^on:ontestfield^to:totestfield^inject_at:testinject");
+
+            var query = GetCensusQueryFactory().Create(service);
+
+            var joinedService = query.JoinService("joinedservice",j=> {
+                j.ToField("totestfield");
+                j.OnField("ontestfield");
+                j.WithInjectAt("testinject");
+                j.Where("field1").Equals("12");
+                j.Where("field2").Equals("34");
+            });
+
+            var censusUri = query.GetUri();
+
+            Assert.AreEqual(expectedUri, censusUri);
+        }
+
+        [TestMethod]
         public void Census_AddJoinWithSubJoin()
         {
             var service = "character";
@@ -285,6 +309,25 @@ namespace DaybreakGames.Census.Test
 
             Assert.AreEqual(expectedUri, censusUri);
         }
+
+        public void Census_AddJoinWithSubJoin_WithConfig()
+        {
+            var service = "character";
+            var ns = "ps2";
+            var key = "testkey";
+
+            var expectedUri = new Uri($"http://{Constants.CensusEndpoint}/s:{key}/get/{ns}/{service}/?c:join=joinedservice^on:testfield(subjoined^list:true)");
+
+            var query = GetCensusQueryFactory().Create(service);
+
+            query.JoinService("joinedservice",j=>j.OnField("testfield"))
+                 .JoinService("subjoined",j=>j.IsList(true));
+
+            var censusUri = query.GetUri();
+
+            Assert.AreEqual(expectedUri, censusUri);
+        }
+
 
         [TestMethod]
         public void Census_AddTree()


### PR DESCRIPTION
The methods for configuring the properties of collection joins (IsList, WithInjectAt...) all return void instead of the join,
so additional subjoins or more than one configuration method cannot be chained without saving the join objects to temp variables.

With the addition of a lambda parameter to the JoinService methods, it is possible to configure the joins and keep the chain going:

    query.JoinService("joinedservice",j=>j.OnField("testfield")).JoinService("subjoined",j=>j.IsList(true));
