### PR TITLE
Allow websocket endpoint to be configurable and add LogicalAndCharactersWithWorlds stream option

### DIFF
--- a/src/DaybreakGames.Census/CensusOptions.cs
+++ b/src/DaybreakGames.Census/CensusOptions.cs
@@ -4,6 +4,7 @@
     {
         public string CensusServiceId { get; set; } = Constants.DefaultServiceId;
         public string CensusServiceNamespace { get; set; } = Constants.DefaultServiceNamespace;
+        public string CensusWebsocketEndpoint { get; set; } = Constants.CensusWebsocketEndpoint;
         public bool LogCensusErrors { get; set; } = false;
     }
 }

--- a/src/DaybreakGames.Census/DaybreakGames.Census.csproj
+++ b/src/DaybreakGames.Census/DaybreakGames.Census.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
     
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <Description>
 This is an UNOFFICIAL package and is in no way associated or supported by Daybreak Games Company.
 Please see the project page for documentation.

--- a/src/DaybreakGames.Census/Stream/CensusStreamClient.cs
+++ b/src/DaybreakGames.Census/Stream/CensusStreamClient.cs
@@ -26,6 +26,7 @@ namespace DaybreakGames.Census.Stream
 
         private string _serviceId { get; set; }
         private string _serviceNamespace { get; set; }
+        private string _endpoint { get; set; }
 
         public CensusStreamClient(IOptions<CensusOptions> options, ILogger<CensusStreamClient> logger)
         {
@@ -127,8 +128,9 @@ namespace DaybreakGames.Census.Stream
         {
             var ns = _serviceNamespace ?? _options.Value.CensusServiceNamespace ?? Constants.DefaultServiceNamespace;
             var sId = _serviceId ?? _options.Value.CensusServiceId ?? Constants.DefaultServiceId;
+            var endpoint = _endpoint ?? _options.Value.CensusWebsocketEndpoint ?? Constants.CensusWebsocketEndpoint;
 
-            return new Uri($"{Constants.CensusWebsocketEndpoint}?environment={ns}&service-id=s:{sId}");
+            return new Uri($"{endpoint}?environment={ns}&service-id=s:{sId}");
         }
 
         public CensusStreamClient SetServiceId(string serviceId)
@@ -151,6 +153,18 @@ namespace DaybreakGames.Census.Stream
             }
 
             _serviceNamespace = serviceNamespace;
+
+            return this;
+        }
+
+        public CensusStreamClient SetEndpoint(string endpoint)
+        {
+            if (string.IsNullOrWhiteSpace(endpoint))
+            {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
+
+            _endpoint = endpoint;
 
             return this;
         }

--- a/src/DaybreakGames.Census/Stream/CensusStreamSubscription.cs
+++ b/src/DaybreakGames.Census/Stream/CensusStreamSubscription.cs
@@ -9,5 +9,6 @@ namespace DaybreakGames.Census.Stream
         public IEnumerable<string> Characters { get; set; }
         public IEnumerable<string> Worlds { get; set; }
         public IEnumerable<string> EventNames { get; set; }
+        public bool LogicalAndCharactersWithWorlds { get; set; }
     }
 }

--- a/src/DaybreakGames.Census/Stream/ICensusStreamClient.cs
+++ b/src/DaybreakGames.Census/Stream/ICensusStreamClient.cs
@@ -8,6 +8,7 @@ namespace DaybreakGames.Census.Stream
     {
         CensusStreamClient SetServiceId(string serviceId);
         CensusStreamClient SetServiceNamespace(string serviceNamespace);
+        CensusStreamClient SetEndpoint(string endpoint);
         CensusStreamClient OnConnect(Func<ReconnectionType, Task> onConnect);
         CensusStreamClient OnDisconnect(Func<DisconnectionInfo, Task> onDisconnect);
         CensusStreamClient OnMessage(Func<string, Task> onMessage);


### PR DESCRIPTION
**Allow websocket endpoint to be configurable**
Could be used to use the community nanite systems stream forward instead. (https://nanite-systems.net/)

**LogicalAndCharactersWithWorlds**
This option is missing in the current StreamSubscription Implementation.
From the ps2 census documentation (http://census.daybreakgames.com/):
_If you subscribe to a set of worlds and characters the default is to send you messages where either the world OR the character matches. You can override this with 'logicalAndCharactersWithWorlds'._

